### PR TITLE
RFC: Correct default ip address

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ optional arguments:
   -h, --help            show this help message and exit
   -w WEB.LISTEN_ADDRESS, --web.listen-address WEB.LISTEN_ADDRESS
                         Interface and port to listen on, in the format of "ip_address:port".
-                        The IP can be omitted to listen on all interfaces. (default: 127.0.0.1:9795)
+                        If the IP is omitted, the exporter listens on all interfaces. (default: 0.0.0.0:9795)
   -c CONFIG, --config CONFIG
                         Configuration JSON file containing UPS addresses and login info (default: None)
   -k, --insecure        Allow the exporter to connect to UPSs with self-signed SSL certificates (default: False)
@@ -50,7 +50,7 @@ optional arguments:
 ```
 
 ## Defaults:
-* Default host-address is localhost
+* Default host-address is `0.0.0.0`
 * Default port is 9795 (see also: [Prometheus default port allocations](https://github.com/prometheus/prometheus/wiki/Default-port-allocations))
 * Login timeout is set to 3 seconds
 * Other request timeouts are set to 2 seconds

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ optional arguments:
 
 # Testing:
 
-Install requirements with 
+Install requirements with
 
-    pip install -r test-requirements.py
+    pip install -r test-requirements.txt
 
 Runt tests with
 

--- a/prometheus_eaton_ups_exporter.py
+++ b/prometheus_eaton_ups_exporter.py
@@ -11,7 +11,7 @@ from prometheus_eaton_ups_exporter.scraper_globals import REQUEST_TIMEOUT
 from prometheus_eaton_ups_exporter.exporter import UPSMultiExporter
 
 DEFAULT_PORT = 9795
-DEFAULT_HOST = "127.0.0.1"
+DEFAULT_HOST = "0.0.0.0"
 
 
 class CustomFormatter(HelpFormatter):
@@ -56,7 +56,7 @@ def create_parser():
         '-w', '--web.listen-address',
         help='Interface and port to listen on, '
              'in the format of "ip_address:port".\n'
-             'The IP can be omitted to listen on all interfaces.',
+             'If the IP is omitted, the exporter listens on all interfaces.',
         default=f"{DEFAULT_HOST}:{DEFAULT_PORT}"
     )
 
@@ -104,10 +104,13 @@ def split_listen_address(listen_address):
     """Split listen address into host and port."""
     if ':' in listen_address:
         host_address, port = listen_address.split(':')
-        if port == "":
-            port = DEFAULT_PORT
     else:
         host_address = listen_address
+
+    # if host_address or port were not specified, use default values
+    if not host_address:
+        host_address = DEFAULT_HOST
+    if not port:
         port = DEFAULT_PORT
 
     return host_address, port

--- a/prometheus_eaton_ups_exporter.py
+++ b/prometheus_eaton_ups_exporter.py
@@ -18,15 +18,11 @@ class CustomFormatter(HelpFormatter):
     """Custom argparse formatter to provide defaults and to split newlines."""
 
     def _split_lines(self, text, width):
-        """
-        Help message formatter which retains formatting of all help text.
-        """
+        """Help message formatter which retains formatting of all help text."""
         return text.splitlines()
 
     def _get_help_string(self, action):
-        """
-        Help message formatter which adds default values to argument help.
-        """
+        """Help message formatter which adds default values to argument help."""
         help = action.help
         if '%(default)' not in action.help:
             if action.default is not SUPPRESS:


### PR DESCRIPTION
This changes the default IP address: `DEFAULT_HOST = "0.0.0.0"`.
(The help-text needs no separate change, since it is an f-string and uses the  `DEFAULT_HOST`)

While trying to reproduce the error described by @aqw I noticed an error in the README.md which I fixed, too.
Also I could not stop myself from normalizing the line breaks doc-strings.