### PR TITLE
exporter.py: normalize whitespace according to pep8

### DIFF
--- a/prometheus_eaton_ups_exporter/exporter.py
+++ b/prometheus_eaton_ups_exporter/exporter.py
@@ -92,7 +92,7 @@ class UPSExporter:
                 'UPS input current (A)',
                 labels=['ups_id']
             )
-            gauge.add_metric([ups_id], inputs_rm.get('current',0))
+            gauge.add_metric([ups_id], inputs_rm.get('current', 0))
             yield gauge
 
             gauge = GaugeMetricFamily(
@@ -166,7 +166,8 @@ class UPSExporter:
                 labels=['ups_id']
             )
             gauge.add_metric(
-                [ups_id], int(powerbank_m.get('remainingChargeCapacity',0)) / 100
+                [ups_id],
+                int(powerbank_m.get('remainingChargeCapacity', 0)) / 100
             )
             yield gauge
 


### PR DESCRIPTION
note: whenever first-time contributors create a merge request, the CI does not run without starting it manually.

Additionally, if a minor flake8/pyre error occours, the pytests are not executed. This requires to test code manually to verify its correctness, and slows down the review.